### PR TITLE
Apply route guards

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,17 +4,20 @@ import { HomePageComponent } from './home/home-page/home-page.component';
 import { PatientRegistrationPageComponent } from './patient-registration/patient-registration-page/patient-registration-page.component';
 import { MedicalAppointmentRegPageComponent } from './medical-appoint-reg/medical-appointment-reg-page/medical-appointment-reg-page.component';
 import { ExamRegisterPageComponent } from './exam-register/exam-register-page/exam-register-page.component';
+import { authGuard } from './shared/guards/auth.guard';
+import { authChildGuard } from './shared/guards/auth-child.guard';
 
 export const routes: Routes = [
     { path: '', component: LoginPageComponent },
-    { path: 'home', component: HomePageComponent },
-    { path: 'registro-paciente/:id', component: PatientRegistrationPageComponent },
-    { path: 'registro-paciente', component: PatientRegistrationPageComponent },
-    { path: 'registro-consulta/:id', component: MedicalAppointmentRegPageComponent },
-    { path: 'registro-consulta', component: MedicalAppointmentRegPageComponent },
-    { path: 'registro-exame/:id', component: ExamRegisterPageComponent },
-    { path: 'registro-exame', component: ExamRegisterPageComponent },
+    { path: 'home', component: HomePageComponent, canActivate: [authGuard] },
+    { path: 'registro-paciente/:id', component: PatientRegistrationPageComponent, canActivate: [authGuard] },
+    { path: 'registro-paciente', component: PatientRegistrationPageComponent, canActivate: [authGuard] },
+    { path: 'registro-consulta/:id', component: MedicalAppointmentRegPageComponent, canActivate: [authGuard] },
+    { path: 'registro-consulta', component: MedicalAppointmentRegPageComponent, canActivate: [authGuard] },
+    { path: 'registro-exame/:id', component: ExamRegisterPageComponent, canActivate: [authGuard] },
+    { path: 'registro-exame', component: ExamRegisterPageComponent, canActivate: [authGuard] },
     { path: 'lista-prontuarios',
+        canActivateChild: [authChildGuard],
         loadChildren:    
         () => import('../app/shared/shared.module').then(m => m.SharedModule)
     },

--- a/src/app/login/login.service.ts
+++ b/src/app/login/login.service.ts
@@ -7,6 +7,7 @@ import { Router } from '@angular/router';
 export class LoginService {
   email!: string;
   password!: string;
+  isLogged: boolean = false;
 
   constructor(private router: Router) { }
 

--- a/src/app/shared/guards/auth-child.guard.spec.ts
+++ b/src/app/shared/guards/auth-child.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateChildFn } from '@angular/router';
+
+import { authChildGuard } from './auth-child.guard';
+
+describe('authChildGuard', () => {
+  const executeGuard: CanActivateChildFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authChildGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/shared/guards/auth-child.guard.ts
+++ b/src/app/shared/guards/auth-child.guard.ts
@@ -1,0 +1,17 @@
+import { inject } from '@angular/core';
+import { CanActivateChildFn, Router } from '@angular/router';
+
+export const authChildGuard: CanActivateChildFn = (childRoute, state) => {
+  const router = inject(Router);
+
+  let isLogged = localStorage.getItem('isLogged') === 'true';
+  let id = childRoute.params['id'];
+  let isIdNumber = id ? /^\d+$/.test(id) : true;
+
+  if(isLogged && isIdNumber) {
+    return true;
+  }
+
+  router.navigate(['']);
+  return false;
+};

--- a/src/app/shared/guards/auth.guard.spec.ts
+++ b/src/app/shared/guards/auth.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/shared/guards/auth.guard.ts
+++ b/src/app/shared/guards/auth.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { LoginService } from '../../login/login.service';
+
+export const authGuard: CanActivateFn = (route, state) => {
+  const loginService = inject(LoginService);
+  const router = inject(Router);
+
+  if(loginService.isLogged || localStorage.getItem('isLogged') === 'true') {
+    return true;
+  }
+  
+  router.navigate(['']);
+  return false;
+};


### PR DESCRIPTION
Applied CanActivate type route guard on all routes, except on the login page. For the child routes of the medical records page, a CanActivateChild type route guard was applied.